### PR TITLE
chore: promote k8s-node to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-780p1-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-780p1-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-60m3o
+  name: jx-verify-gc-jobs-780p1
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-nvsyo
+    app: jx-verify-gc-jobs-bl71v
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-xqfli-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-xqfli-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-bd2m2
+  name: jx-verify-gc-jobs-xqfli
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-staging
+  namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-3syap-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-3syap-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-axag2
+  name: jx-verify-gc-jobs-3syap
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-production
+  namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-cjytq-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-cjytq-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-gq7gd
+  name: jx-verify-gc-jobs-cjytq
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-wkp0m
+    app: jx-verify-gc-jobs-u915p
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/k8s-node/k8s-node-ingress.yaml
+++ b/config-root/namespaces/jx-staging/k8s-node/k8s-node-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: k8s-node/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'k8s-node'
+  name: k8s-node
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: k8s-node
+                port:
+                  number: 80
+      host: k8s-node-jx-staging.34.123.58.147.nip.io

--- a/config-root/namespaces/jx-staging/k8s-node/k8s-node-k8s-node-deploy.yaml
+++ b/config-root/namespaces/jx-staging/k8s-node/k8s-node-k8s-node-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: k8s-node/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-node-k8s-node
+  labels:
+    draft: draft-app
+    chart: "k8s-node-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'k8s-node'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: k8s-node-k8s-node
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: k8s-node-k8s-node
+    spec:
+      serviceAccountName: k8s-node-k8s-node
+      containers:
+        - name: k8s-node
+          image: "gcr.io/vocal-tracer-324708/k8s-node:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 0.1
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/k8s-node/k8s-node-k8s-node-sa.yaml
+++ b/config-root/namespaces/jx-staging/k8s-node/k8s-node-k8s-node-sa.yaml
@@ -1,0 +1,10 @@
+# Source: k8s-node/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-node-k8s-node
+  annotations:
+    meta.helm.sh/release-name: 'k8s-node'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/k8s-node/k8s-node-svc.yaml
+++ b/config-root/namespaces/jx-staging/k8s-node/k8s-node-svc.yaml
@@ -1,0 +1,20 @@
+# Source: k8s-node/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-node
+  labels:
+    chart: "k8s-node-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'k8s-node'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: k8s-node-k8s-node

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,12 @@
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> k8s-node </a></td>
+	      <td>0.0.1</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -32,6 +32,18 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-staging/jx-verify
+  - apiVersion: v1
+    appVersion: 0.0.1
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-09-24T14:44:46Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2021-09-24T14:44:46Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=vocal-tracer-324708&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-included-vervet%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fk8s-node&dateRangeUnbound=both
+    name: k8s-node
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.34.123.58.147.nip.io
+    resourcePath: config-root/namespaces/jx-staging/k8s-node
+    version: 0.0.1
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jxgh
   url: https://jenkins-x-charts.github.io/repo
+- name: dev
+  url: http://chartmuseum-jx.34.123.58.147.nip.io
 releases:
 - chart: jxgh/jx-verify
   name: jx-verify
   namespace: jx-staging
   values:
   - jx-values.yaml
+- chart: dev/k8s-node
+  version: 0.0.1
+  name: k8s-node
+  namespace: jx-staging
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.1
   name: k8s-node
   namespace: jx-staging
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote k8s-node to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
