### PR TITLE
chore: promote k8s-node to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-8cl86-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-8cl86-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-xqfli
+  name: jx-verify-gc-jobs-8cl86
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-eej2h-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-eej2h-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-cjytq
+  name: jx-verify-gc-jobs-eej2h
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-u915p
+    app: jx-verify-gc-jobs-ovu70
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-04qkx-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-04qkx-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-780p1
+  name: jx-verify-gc-jobs-04qkx
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-bl71v
+    app: jx-verify-gc-jobs-dunnm
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-ypih5-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-ypih5-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-3syap
+  name: jx-verify-gc-jobs-ypih5
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/k8s-node/k8s-node-k8s-node-deploy.yaml
+++ b/config-root/namespaces/jx-staging/k8s-node/k8s-node-k8s-node-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: k8s-node-k8s-node
   labels:
     draft: draft-app
-    chart: "k8s-node-0.0.1"
+    chart: "k8s-node-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'k8s-node'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: k8s-node-k8s-node
       containers:
         - name: k8s-node
-          image: "gcr.io/vocal-tracer-324708/k8s-node:0.0.1"
+          image: "gcr.io/vocal-tracer-324708/k8s-node:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/k8s-node/k8s-node-svc.yaml
+++ b/config-root/namespaces/jx-staging/k8s-node/k8s-node-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: k8s-node
   labels:
-    chart: "k8s-node-0.0.1"
+    chart: "k8s-node-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'k8s-node'

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> k8s-node </a></td>
-	      <td>0.0.1</td>
+	      <td>0.0.2</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -33,17 +33,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-staging/jx-verify
   - apiVersion: v1
-    appVersion: 0.0.1
+    appVersion: 0.0.2
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-09-24T14:44:46Z"
+    firstDeployed: "2021-09-25T13:46:32Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2021-09-24T14:44:46Z"
+    lastDeployed: "2021-09-25T13:46:32Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=vocal-tracer-324708&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-included-vervet%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fk8s-node&dateRangeUnbound=both
     name: k8s-node
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.34.123.58.147.nip.io
     resourcePath: config-root/namespaces/jx-staging/k8s-node
-    version: 0.0.1
+    version: 0.0.2
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/k8s-node
-  version: 0.0.1
+  version: 0.0.2
   name: k8s-node
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote k8s-node to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
