### PR TITLE
chore: promote k8s-node to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-3ylm1-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-3ylm1-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-nlvjt
+  name: jx-verify-gc-jobs-3ylm1
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-5kbsn
+    app: jx-verify-gc-jobs-hrgmo
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-omknn-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-omknn-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-cng26
+  name: jx-verify-gc-jobs-omknn
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-aoavq-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-aoavq-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-uclzu
+  name: jx-verify-gc-jobs-aoavq
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-ws1dn
+    app: jx-verify-gc-jobs-ymiyh
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-pfbt3-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-pfbt3-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-tmjom
+  name: jx-verify-gc-jobs-pfbt3
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/k8s-node/k8s-node-k8s-node-deploy.yaml
+++ b/config-root/namespaces/jx-staging/k8s-node/k8s-node-k8s-node-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: k8s-node-k8s-node
   labels:
     draft: draft-app
-    chart: "k8s-node-0.0.4"
+    chart: "k8s-node-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'k8s-node'
@@ -25,19 +25,19 @@ spec:
       serviceAccountName: k8s-node-k8s-node
       containers:
         - name: k8s-node
-          image: "gcr.io/vocal-tracer-324708/k8s-node:0.0.4"
+          image: "gcr.io/vocal-tracer-324708/k8s-node:0.0.5"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.4
+              value: 0.0.5
           envFrom: null
           ports:
             - name: http
-              containerPort: 3000
+              containerPort: 8080
           livenessProbe:
             httpGet:
               path: /
-              port: 3000
+              port: 8080
             initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
@@ -45,7 +45,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: 3000
+              port: 8080
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/config-root/namespaces/jx-staging/k8s-node/k8s-node-svc.yaml
+++ b/config-root/namespaces/jx-staging/k8s-node/k8s-node-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: k8s-node
   labels:
-    chart: "k8s-node-0.0.4"
+    chart: "k8s-node-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'k8s-node'
@@ -13,7 +13,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 80
-      targetPort: 3000
+      targetPort: 8080
       protocol: TCP
       name: http
   selector:

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> k8s-node </a></td>
-	      <td>0.0.4</td>
+	      <td>0.0.5</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -33,17 +33,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-staging/jx-verify
   - apiVersion: v1
-    appVersion: 0.0.4
+    appVersion: 0.0.5
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-09-26T09:05:13Z"
+    firstDeployed: "2021-09-26T09:11:48Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2021-09-26T09:05:13Z"
+    lastDeployed: "2021-09-26T09:11:48Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=vocal-tracer-324708&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-included-vervet%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fk8s-node&dateRangeUnbound=both
     name: k8s-node
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.34.123.58.147.nip.io
     resourcePath: config-root/namespaces/jx-staging/k8s-node
-    version: 0.0.4
+    version: 0.0.5
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/k8s-node
-  version: 0.0.4
+  version: 0.0.5
   name: k8s-node
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote k8s-node to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
