### PR TITLE
chore: promote k8s-reactjs to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-owydb-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-owydb-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-yauil
+  name: jx-verify-gc-jobs-owydb
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-wiopt
+    app: jx-verify-gc-jobs-uihgq
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-prkdo-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-prkdo-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-hnb9z
+  name: jx-verify-gc-jobs-prkdo
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/k8s-reactjs/k8s-reactjs-ingress.yaml
+++ b/config-root/namespaces/jx-production/k8s-reactjs/k8s-reactjs-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: k8s-reactjs/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'k8s-reactjs'
+  name: k8s-reactjs
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: k8s-reactjs
+                port:
+                  number: 80
+      host: k8s-reactjs-jx-production.34.123.58.147.nip.io

--- a/config-root/namespaces/jx-production/k8s-reactjs/k8s-reactjs-k8s-reactjs-deploy.yaml
+++ b/config-root/namespaces/jx-production/k8s-reactjs/k8s-reactjs-k8s-reactjs-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: k8s-reactjs/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-reactjs-k8s-reactjs
+  labels:
+    draft: draft-app
+    chart: "k8s-reactjs-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'k8s-reactjs'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: k8s-reactjs-k8s-reactjs
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: k8s-reactjs-k8s-reactjs
+    spec:
+      serviceAccountName: k8s-reactjs-k8s-reactjs
+      containers:
+        - name: k8s-reactjs
+          image: "gcr.io/vocal-tracer-324708/k8s-reactjs:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/k8s-reactjs/k8s-reactjs-k8s-reactjs-sa.yaml
+++ b/config-root/namespaces/jx-production/k8s-reactjs/k8s-reactjs-k8s-reactjs-sa.yaml
@@ -1,0 +1,10 @@
+# Source: k8s-reactjs/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-reactjs-k8s-reactjs
+  annotations:
+    meta.helm.sh/release-name: 'k8s-reactjs'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/k8s-reactjs/k8s-reactjs-svc.yaml
+++ b/config-root/namespaces/jx-production/k8s-reactjs/k8s-reactjs-svc.yaml
@@ -1,0 +1,20 @@
+# Source: k8s-reactjs/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-reactjs
+  labels:
+    chart: "k8s-reactjs-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'k8s-reactjs'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: k8s-reactjs-k8s-reactjs

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-emsdb-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-emsdb-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-hdsrj
+  name: jx-verify-gc-jobs-emsdb
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-n10xs
+    app: jx-verify-gc-jobs-6sufv
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-mr3fe-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-mr3fe-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-hlocg
+  name: jx-verify-gc-jobs-mr3fe
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,12 @@
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> k8s-reactjs </a></td>
+	      <td>0.0.1</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -16,6 +16,18 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-production/jx-verify
+  - apiVersion: v1
+    appVersion: 0.0.1
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-09-26T16:31:25Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2021-09-26T16:31:25Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=vocal-tracer-324708&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-included-vervet%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Fk8s-reactjs&dateRangeUnbound=both
+    name: k8s-reactjs
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.34.123.58.147.nip.io
+    resourcePath: config-root/namespaces/jx-production/k8s-reactjs
+    version: 0.0.1
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jxgh
   url: https://jenkins-x-charts.github.io/repo
+- name: dev
+  url: http://chartmuseum-jx.34.123.58.147.nip.io
 releases:
 - chart: jxgh/jx-verify
   name: jx-verify
   namespace: jx-production
   values:
   - jx-values.yaml
+- chart: dev/k8s-reactjs
+  version: 0.0.1
+  name: k8s-reactjs
+  namespace: jx-production
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.1
   name: k8s-reactjs
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote k8s-reactjs to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
