### PR TITLE
chore: promote k8s-reactjs to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-vsmb2-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-vsmb2-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-r1jxc
+  name: jx-verify-gc-jobs-vsmb2
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-xi30f
+    app: jx-verify-gc-jobs-zjb3x
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-zyqob-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-zyqob-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-ujkz1
+  name: jx-verify-gc-jobs-zyqob
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-atzcj-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-atzcj-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-xorg9
+  name: jx-verify-gc-jobs-atzcj
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-z8zt7
+    app: jx-verify-gc-jobs-q64td
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-hj0n9-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-hj0n9-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-pyglj
+  name: jx-verify-gc-jobs-hj0n9
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/k8s-reactjs/k8s-reactjs-k8s-reactjs-deploy.yaml
+++ b/config-root/namespaces/jx-staging/k8s-reactjs/k8s-reactjs-k8s-reactjs-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: k8s-reactjs-k8s-reactjs
   labels:
     draft: draft-app
-    chart: "k8s-reactjs-0.0.1"
+    chart: "k8s-reactjs-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'k8s-reactjs'
@@ -25,19 +25,19 @@ spec:
       serviceAccountName: k8s-reactjs-k8s-reactjs
       containers:
         - name: k8s-reactjs
-          image: "gcr.io/vocal-tracer-324708/k8s-reactjs:0.0.1"
+          image: "gcr.io/vocal-tracer-324708/k8s-reactjs:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: 3000
           livenessProbe:
             httpGet:
               path: /
-              port: 8080
+              port: 3000
             initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
@@ -45,7 +45,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: 8080
+              port: 3000
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/config-root/namespaces/jx-staging/k8s-reactjs/k8s-reactjs-svc.yaml
+++ b/config-root/namespaces/jx-staging/k8s-reactjs/k8s-reactjs-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: k8s-reactjs
   labels:
-    chart: "k8s-reactjs-0.0.1"
+    chart: "k8s-reactjs-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'k8s-reactjs'
@@ -13,7 +13,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 80
-      targetPort: 8080
+      targetPort: 3000
       protocol: TCP
       name: http
   selector:

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> k8s-reactjs </a></td>
-	      <td>0.0.1</td>
+	      <td>0.0.2</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -45,17 +45,17 @@
     resourcePath: config-root/namespaces/jx-staging/k8s-node
     version: 0.0.5
   - apiVersion: v1
-    appVersion: 0.0.1
+    appVersion: 0.0.2
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-09-26T16:31:26Z"
+    firstDeployed: "2021-09-26T16:41:40Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2021-09-26T16:31:26Z"
+    lastDeployed: "2021-09-26T16:41:40Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=vocal-tracer-324708&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-included-vervet%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fk8s-reactjs&dateRangeUnbound=both
     name: k8s-reactjs
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.34.123.58.147.nip.io
     resourcePath: config-root/namespaces/jx-staging/k8s-reactjs
-    version: 0.0.1
+    version: 0.0.2
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -21,7 +21,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/k8s-reactjs
-  version: 0.0.1
+  version: 0.0.2
   name: k8s-reactjs
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote k8s-reactjs to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
