### PR TITLE
chore: promote k8s-nestjs to version 0.0.7

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-rge3x-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-rge3x-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-qi73u
+  name: jx-verify-gc-jobs-rge3x
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-staging
+  namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-tlrke-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-tlrke-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-jvdnf
+  name: jx-verify-gc-jobs-tlrke
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-mayob
+    app: jx-verify-gc-jobs-mxdow
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-9keip-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-9keip-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-ucu4l
+  name: jx-verify-gc-jobs-9keip
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-production
+  namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-vrncd-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-vrncd-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-n9wcc
+  name: jx-verify-gc-jobs-vrncd
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-vyrlp
+    app: jx-verify-gc-jobs-xrjvv
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/k8s-nestjs/k8s-nestjs-k8s-nestjs-deploy.yaml
+++ b/config-root/namespaces/jx-staging/k8s-nestjs/k8s-nestjs-k8s-nestjs-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: k8s-nestjs-k8s-nestjs
   labels:
     draft: draft-app
-    chart: "k8s-nestjs-0.0.4"
+    chart: "k8s-nestjs-0.0.7"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'k8s-nestjs'
@@ -25,19 +25,29 @@ spec:
       serviceAccountName: k8s-nestjs-k8s-nestjs
       containers:
         - name: k8s-nestjs
-          image: "gcr.io/vocal-tracer-324708/k8s-nestjs:0.0.4"
+          image: "gcr.io/vocal-tracer-324708/k8s-nestjs:0.0.7"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.4
+              value: 0.0.7
+            - name: DATABASE_HOST
+              value: "postgres-db-lb.jx-staging.svc.cluster.local"
+            - name: DATABASE_NAME
+              value: "app"
+            - name: DATABASE_PASSWORD
+              value: "postgres"
+            - name: DATABASE_PORT
+              value: "5432"
+            - name: DATABASE_USER
+              value: "postgres"
           envFrom: null
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: 3000
           livenessProbe:
             httpGet:
               path: /
-              port: 8080
+              port: 3000
             initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
@@ -45,7 +55,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: 8080
+              port: 3000
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/config-root/namespaces/jx-staging/k8s-nestjs/k8s-nestjs-svc.yaml
+++ b/config-root/namespaces/jx-staging/k8s-nestjs/k8s-nestjs-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: k8s-nestjs
   labels:
-    chart: "k8s-nestjs-0.0.4"
+    chart: "k8s-nestjs-0.0.7"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'k8s-nestjs'
@@ -13,7 +13,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 80
-      targetPort: 8080
+      targetPort: 3000
       protocol: TCP
       name: http
   selector:

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> k8s-nestjs </a></td>
-	      <td>0.0.4</td>
+	      <td>0.0.7</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -57,17 +57,17 @@
     resourcePath: config-root/namespaces/jx-staging/k8s-reactjs
     version: 0.0.6
   - apiVersion: v1
-    appVersion: 0.0.4
+    appVersion: 0.0.7
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-09-28T01:01:37Z"
+    firstDeployed: "2021-09-28T08:35:22Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2021-09-28T01:01:37Z"
+    lastDeployed: "2021-09-28T08:35:22Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=vocal-tracer-324708&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-included-vervet%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fk8s-nestjs&dateRangeUnbound=both
     name: k8s-nestjs
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.34.123.58.147.nip.io
     resourcePath: config-root/namespaces/jx-staging/k8s-nestjs
-    version: 0.0.4
+    version: 0.0.7
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -27,7 +27,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/k8s-nestjs
-  version: 0.0.4
+  version: 0.0.7
   name: k8s-nestjs
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote k8s-nestjs to version 0.0.7

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
